### PR TITLE
Implement authorization with HuggingFace [version for the 2nd Bengali run]

### DIFF
--- a/colab_starter.ipynb
+++ b/colab_starter.ipynb
@@ -69,7 +69,7 @@
       "source": [
         "experiment_name = \"bengali_test_1_auth\"\n",
         "hivemind_version = \"bengali_test_1_auth\"\n",
-        "collaborative_training_version = \"auth-v2\"\n",
+        "collaborative_training_version = \"auth\" \n",
         "%env HF_EXPERIMENT_ID 3\n",
         "\n",
         "!echo \"Installing dependencies...\"\n",

--- a/colab_starter.ipynb
+++ b/colab_starter.ipynb
@@ -36,7 +36,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/mryab/collaborative-training/blob/auth/colab_starter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/mryab/collaborative-training/blob/auth-v2/colab_starter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -69,33 +69,35 @@
       "source": [
         "experiment_name = \"bengali_test_1_auth\"\n",
         "hivemind_version = \"bengali_test_1_auth\"\n",
-        "collaborative_training_version = \"auth\" \n",
-        "syslog_host = '18.191.120.93'\n",
+        "collaborative_training_version = \"auth-v2\"\n",
+        "%env HF_EXPERIMENT_ID 3\n",
         "\n",
         "!echo \"Installing dependencies...\"\n",
         "!pip install git+https://github.com/learning-at-home/hivemind.git@{hivemind_version} >> install.log 2>&1\n",
         "!git clone https://github.com/mryab/collaborative-training -b {collaborative_training_version} >> install.log 2>&1\n",
-        "!cd collaborative-training && pip install -r requirements.txt >> install.log 2>&1 && cd ..\n",
         "%cd ./collaborative-training\n",
+        "!pip install -r requirements.txt >> install.log 2>&1\n",
         "\n",
-        "import shlex\n",
-        "from getpass import getpass\n",
+        "from shlex import quote\n",
         "import torch\n",
+        "from huggingface_auth import authorize_with_huggingface\n",
         "from runner import run_with_logging\n",
+        "\n",
         "assert torch.cuda.is_available(), \"GPU device not found. If running in colab, please retry in a few minutes.\"\n",
         "device_name = torch.cuda.get_device_name(0)\n",
         "microbatch_size = 4 if 'T4' in device_name or 'P100' in device_name else 1\n",
         "print(f\"Running with device {device_name}, local batch size = {microbatch_size}\")\n",
         "\n",
-        "username = shlex.quote(input('Huggingface login: '))\n",
-        "password = shlex.quote(getpass('Huggingface password: '))\n",
-        "\n",
-        "command = f\"\"\"ulimit -n 4096 && HIVEMIND_THREADS=256 HF_USERNAME={username} HF_PASSWORD={password} python ./run_trainer.py \\\n",
-        " --client_mode --averaging_expiration 10 --statistics_expiration 120 \\\n",
+        "authorizer = authorize_with_huggingface()\n",
+        "command = f\"\"\"ulimit -n 4096 && HIVEMIND_THREADS=256 \\\n",
+        " HF_USERNAME={quote(authorizer.username)} HF_PASSWORD={quote(authorizer.password)} \\\n",
+        " python ./run_trainer.py --client_mode --initial_peers {authorizer.coordinator_ip}:{authorizer.coordinator_port} \\\n",
+        " --averaging_expiration 10 --statistics_expiration 120 \\\n",
         " --batch_size_lead 200 --per_device_train_batch_size {microbatch_size} --gradient_accumulation_steps 1 \\\n",
-        " --logging_first_step --logging_steps 100 --run_name {username}  --output_dir ./outputs --overwrite_output_dir --logging_dir ./logs \\\n",
-        " --experiment_prefix {experiment_name} --seed 42\"\"\"\n",
-        "run_with_logging(command, syslog_host, wandb_login=True)"
+        " --logging_first_step --logging_steps 100 --run_name {quote(authorizer.username)} \\\n",
+        " --output_dir ./outputs --overwrite_output_dir --logging_dir ./logs \\\n",
+        " --experiment_prefix {quote(experiment_name)} --seed 42\"\"\"\n",
+        "run_with_logging(command, authorizer.coordinator_ip, wandb_login=True)"
       ],
       "execution_count": null,
       "outputs": [

--- a/colab_starter.ipynb
+++ b/colab_starter.ipynb
@@ -36,7 +36,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/mryab/collaborative-training/blob/auth-v2/colab_starter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/mryab/collaborative-training/blob/auth/colab_starter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/colab_starter.ipynb
+++ b/colab_starter.ipynb
@@ -70,8 +70,7 @@
         "experiment_name = \"bengali_test_1_auth\"\n",
         "hivemind_version = \"bengali_test_1_auth\"\n",
         "collaborative_training_version = \"auth\" \n",
-        "coordinator_ip = '18.191.120.93'\n",
-        "coordinator_port = 31337\n",
+        "syslog_host = '18.191.120.93'\n",
         "\n",
         "!echo \"Installing dependencies...\"\n",
         "!pip install git+https://github.com/learning-at-home/hivemind.git@{hivemind_version} >> install.log 2>&1\n",
@@ -92,11 +91,11 @@
         "password = shlex.quote(getpass('Huggingface password: '))\n",
         "\n",
         "command = f\"\"\"ulimit -n 4096 && HIVEMIND_THREADS=256 HF_USERNAME={username} HF_PASSWORD={password} python ./run_trainer.py \\\n",
-        " --client_mode --initial_peers {coordinator_ip}:{coordinator_port} --averaging_expiration 10 --statistics_expiration 120 \\\n",
+        " --client_mode --averaging_expiration 10 --statistics_expiration 120 \\\n",
         " --batch_size_lead 200 --per_device_train_batch_size {microbatch_size} --gradient_accumulation_steps 1 \\\n",
         " --logging_first_step --logging_steps 100 --run_name {username}  --output_dir ./outputs --overwrite_output_dir --logging_dir ./logs \\\n",
         " --experiment_prefix {experiment_name} --seed 42\"\"\"\n",
-        "run_with_logging(command, coordinator_ip, wandb_login=True)"
+        "run_with_logging(command, syslog_host, wandb_login=True)"
       ],
       "execution_count": null,
       "outputs": [

--- a/huggingface_auth.py
+++ b/huggingface_auth.py
@@ -41,6 +41,9 @@ class HuggingFaceAuthorizer(TokenAuthorizerBase):
         self._password = password
 
         self._authority_public_key = None
+        self.coordinator_ip = None
+        self.coordinator_port = None
+
         self._hf_api = HfApi()
 
     async def get_token(self) -> AccessToken:
@@ -62,6 +65,8 @@ class HuggingFaceAuthorizer(TokenAuthorizerBase):
             response = response.json()
 
             self._authority_public_key = RSAPublicKey.from_bytes(response['auth_server_public_key'].encode())
+            self.coordinator_ip = response['coordinator_ip']
+            self.coordinator_port = response['coordinator_port']
 
             token_dict = response['hivemind_access']
             access_token = AccessToken()

--- a/run_first_peer.py
+++ b/run_first_peer.py
@@ -144,11 +144,7 @@ if __name__ == '__main__':
         logger.warning("No address specified. Attempting to infer address from DNS.")
         coordinator_args.address = get_ip(GoogleDnsProvider)
 
-    try:
-        authorizer = authorize_with_huggingface()
-    except Exception as e:
-        logger.fatal(f'Authorization failed: {e}')
-        sys.exit(1)
+    authorizer = authorize_with_huggingface()
 
     experiment_prefix = coordinator_args.experiment_prefix
     validators, local_public_key = metrics_utils.make_validators(experiment_prefix)

--- a/run_trainer.py
+++ b/run_trainer.py
@@ -204,18 +204,18 @@ def main():
     assert training_args.dataloader_num_workers == 0, 'streaming dataset does not support multiple workers'
     assert not training_args.do_eval, 'local evaluation is not supported (yet)'
 
-    logger.info(f"Found {len(collaboration_args.initial_peers)} initial peers: {collaboration_args.initial_peers}")
-    if len(collaboration_args.initial_peers) == 0:
-        raise ValueError("Please specify at least one network endpoint in initial peers.")
-
-    collaboration_args_dict = asdict(collaboration_args)
-    setup_logging(training_args)
-
     try:
         authorizer = authorize_with_huggingface()
     except Exception as e:
         logger.fatal(f'Authorization failed: {e}')
         sys.exit(1)
+
+    if not collaboration_args.initial_peers:
+        collaboration_args.initial_peers = [f'{authorizer.coordinator_ip}:{authorizer.coordinator_port}']
+    logger.info(f"Using {len(collaboration_args.initial_peers)} initial peers: {collaboration_args.initial_peers}")
+
+    collaboration_args_dict = asdict(collaboration_args)
+    setup_logging(training_args)
 
     # Set seed before initializing model.
     set_seed(training_args.seed)

--- a/run_trainer.py
+++ b/run_trainer.py
@@ -204,11 +204,7 @@ def main():
     assert training_args.dataloader_num_workers == 0, 'streaming dataset does not support multiple workers'
     assert not training_args.do_eval, 'local evaluation is not supported (yet)'
 
-    try:
-        authorizer = authorize_with_huggingface()
-    except Exception as e:
-        logger.fatal(f'Authorization failed: {e}')
-        sys.exit(1)
+    authorizer = authorize_with_huggingface()
 
     if not collaboration_args.initial_peers:
         collaboration_args.initial_peers = [f'{authorizer.coordinator_ip}:{authorizer.coordinator_port}']


### PR DESCRIPTION
In addition to #6, this PR implements the following:

1. Explicit whitelisting by moderators (without using `robot-bengali` to add a new collaborator automatically).
2. Retries with exponential delays for unexpected (i.e. not just invalid username/password) exceptions during authorization.
3. Using coordinator_ip/port returned by the HuggingFace API (both as a DHT initial peer and syslog host) instead of hardcoding them.
4. A better CLI:
     - If username/password are invalid, the CLI shows a user-friendly message, then shows the inputs again.
     - If an email is used instead of a username (a popular misconception), the CLI shows a user-friendly message, then shows the input again.

Based on the protocol from https://github.com/learning-at-home/hivemind/issues/253 implemented in https://github.com/learning-at-home/hivemind/pull/255.